### PR TITLE
Make raw pointer deref explicit to satisfy dangerous_implicit_autoref…

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -216,7 +216,7 @@ extern "C" fn tokenizers_get_decode_str(
 ) {
     unsafe {
         *out_cstr = (*handle).decode_str.as_mut_ptr();
-        *out_len = (*handle).decode_str.len();
+        *out_len = (&(*handle).decode_str).len();
     }
 }
 
@@ -249,7 +249,7 @@ extern "C" fn tokenizers_id_to_token(
         };
 
         *out_cstr = (*handle).id_to_token_result.as_mut_ptr();
-        *out_len = (*handle).id_to_token_result.len();
+        *out_len = (&(*handle).id_to_token_result).len();
     }
 }
 


### PR DESCRIPTION
…s lint (#87)

Explicitly create a reference from `handle` when calling `.len()` to avoid implicit autoref on a raw pointer and comply with Rust's safety requirements.

noticed in vajra here:
https://github.com/project-vajra/vajra/actions/runs/16844555765/job/47721791119?pr=331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal method of obtaining string lengths without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->